### PR TITLE
Only allow one preferences window at a time

### DIFF
--- a/Twig/Base.lproj/Main.storyboard
+++ b/Twig/Base.lproj/Main.storyboard
@@ -541,7 +541,7 @@
         <!--Window Controller-->
         <scene sceneID="UqC-3D-TJP">
             <objects>
-                <windowController id="Ul4-m2-Yud" customClass="PreferencesWindowController" customModule="Twig" customModuleProvider="target" sceneMemberID="viewController">
+                <windowController showSeguePresentationStyle="single" id="Ul4-m2-Yud" customClass="PreferencesWindowController" customModule="Twig" customModuleProvider="target" sceneMemberID="viewController">
                     <window key="window" title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="alertPanel" frameAutosaveName="" titlebarAppearsTransparent="YES" id="GdU-QC-Lde">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>


### PR DESCRIPTION
Here's a minor bug I found: when I press <kbd>⌘</kbd> + <kbd>,</kbd> repeatedly, multiple copies of the preferences window appear. This PR ensures that only one is open at a time.