### PR TITLE
Add H6 to menu items

### DIFF
--- a/Twig/Base.lproj/Main.storyboard
+++ b/Twig/Base.lproj/Main.storyboard
@@ -485,6 +485,11 @@
                                                 <action selector="h5WithSender:" target="Ady-hI-5gd" id="k1V-p7-TCj"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Heading 6" keyEquivalent="6" id="hZl-Al-8hZ">
+                                            <connections>
+                                                <action selector="h6WithSender:" target="Ady-hI-5gd" id="C6m-fa-6CH"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="sE2-tt-JAH"/>
                                         <menuItem title="Math" keyEquivalent="m" id="lDB-Lf-ApR">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES"/>

--- a/Twig/Controllers/MarkdownViewController.swift
+++ b/Twig/Controllers/MarkdownViewController.swift
@@ -144,6 +144,11 @@ class MarkdownViewController: NSViewController, NSTextViewDelegate {
     reloadUI()
   }
 
+  @IBAction func h6(sender: NSMenuItem) {
+    markdownTextView.replace(left: "###### ", atLineStart: true)
+    reloadUI()
+  }
+
   @IBAction func math(sender: NSMenuItem) {
     markdownTextView.replace(left: "$", right: "$")
     reloadUI()


### PR DESCRIPTION
I noticed only H1 thru H5 were present in the title bar 'Format' menu.